### PR TITLE
add attachmment .path to xml entry as a fallback for automatic attachment

### DIFF
--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -1,4 +1,4 @@
-type FileExtension = 'image/png' | 'text/plain' | 'video/webm' | 'application/zip';
+export type FileExtension = 'image/png' | 'text/plain' | 'video/webm' | 'application/zip';
 
 class ContentTypeMapper{
 

--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -1,5 +1,8 @@
+type FileExtension = 'image/png' | 'text/plain' | 'video/webm' | 'application/zip';
+
 class ContentTypeMapper{
-  getFileExtenion(contentType: string) {
+
+  getFileExtenion(contentType: FileExtension): string {
     switch (contentType) {
       case 'image/png':
         return '.png';
@@ -9,6 +12,8 @@ class ContentTypeMapper{
         return '.webm';
       case 'application/zip':
         return '.zip';
+      default:
+        throw new console.warn(`could not map filetype of: ${contentType} to a correct ending`);
     }
   }
 }

--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -1,0 +1,22 @@
+class ContentTypeMapper{
+  fileExtension: string;
+
+  constructor() {
+    this.fileExtension = this.fileExtension;
+  }
+
+  getFileExtenion(contentType: string) {
+    switch (contentType) {
+      case 'image/png':
+        return '.png';
+      case 'text/plain':
+        return '.txt';
+      case 'video/webm':
+        return '.webm';
+      case 'application/zip':
+        return '.zip';
+    }
+  }
+}
+
+export default new ContentTypeMapper();

--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -1,10 +1,4 @@
 class ContentTypeMapper{
-  fileExtension: string;
-
-  constructor() {
-    this.fileExtension = this.fileExtension;
-  }
-
   getFileExtenion(contentType: string) {
     switch (contentType) {
       case 'image/png':

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import type { FullConfig, FullResult, Reporter, Suite, TestCase } from '@playwright/test/reporter';
 import { formatFailure, stripAnsiEscapes } from './base';
 import { assert } from 'playwright-core/lib/utils';
+import type { FileExtension } from './contentType.mapper';
 import contentTypeMapper from './contentType.mapper';
 
 export function monotonicTime(): number {
@@ -211,7 +212,7 @@ class XrayJUnitReporter implements Reporter {
           }
 
           if (contents) {
-            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? contentTypeMapper.getFileExtenion(attachment.contentType) : '');
+            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? contentTypeMapper.getFileExtenion(attachment.contentType as  FileExtension) : '');
             const item: XMLEntry = {
               name: 'item',
               attributes: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import type { FullConfig, FullResult, Reporter, Suite, TestCase } from '@playwright/test/reporter';
 import { formatFailure, stripAnsiEscapes } from './base';
 import { assert } from 'playwright-core/lib/utils';
+import contentTypeMapper from './contentType.mapper';
 
 export function monotonicTime(): number {
   const [seconds, nanoseconds] = process.hrtime();
@@ -210,7 +211,7 @@ class XrayJUnitReporter implements Reporter {
           }
 
           if (contents) {
-            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? path.extname(attachment.path) : '');
+            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? contentTypeMapper.getFileExtenion(attachment.contentType) : '');
             const item: XMLEntry = {
               name: 'item',
               attributes: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,10 +210,11 @@ class XrayJUnitReporter implements Reporter {
           }
 
           if (contents) {
+            const attachmentName = attachment.name + ((attachment.path && !path.extname(attachment.name)) ? path.extname(attachment.path) : '');
             const item: XMLEntry = {
               name: 'item',
               attributes: {
-                name: attachment.name
+                name: attachmentName
               },
               text: contents
             };

--- a/tests/reporter-junit.spec.ts
+++ b/tests/reporter-junit.spec.ts
@@ -411,7 +411,8 @@ test('should embed attachments to a custom testcase property, if explicitly requ
         const file = testInfo.outputPath('evidence1.txt');
         require('fs').writeFileSync(file, 'hello', 'utf8');
         testInfo.attachments.push({ name: 'evidence1.txt', path: file, contentType: 'text/plain' });
-        testInfo.attachments.push({ name: 'evidence2.txt', body: Buffer.from('world'), contentType: 'text/plain' });
+        testInfo.attachments.push({ name: 'evidence2_without_extension', path: file, contentType: 'text/plain' });
+        testInfo.attachments.push({ name: 'evidence3.txt', body: Buffer.from('world'), contentType: 'text/plain' });
         // await testInfo.attach('evidence1.txt', { path: file, contentType: 'text/plain' });
         // await testInfo.attach('evidence2.txt', { body: Buffer.from('world'), contentType: 'text/plain' });
         console.log('log here');
@@ -425,8 +426,10 @@ test('should embed attachments to a custom testcase property, if explicitly requ
   expect(testcase['properties'][0]['property'][0]['$']['name']).toBe('testrun_evidence');
   expect(testcase['properties'][0]['property'][0]['item'][0]['$']['name']).toBe('evidence1.txt');
   expect(testcase['properties'][0]['property'][0]['item'][0]['_']).toBe('\naGVsbG8=\n');
-  expect(testcase['properties'][0]['property'][0]['item'][1]['$']['name']).toBe('evidence2.txt');
-  expect(testcase['properties'][0]['property'][0]['item'][1]['_']).toBe('\nd29ybGQ=\n');
+  expect(testcase['properties'][0]['property'][0]['item'][1]['$']['name']).toBe('evidence2_without_extension.txt');
+  expect(testcase['properties'][0]['property'][0]['item'][1]['_']).toBe('\naGVsbG8=\n');
+  expect(testcase['properties'][0]['property'][0]['item'][2]['$']['name']).toBe('evidence3.txt');
+  expect(testcase['properties'][0]['property'][0]['item'][2]['_']).toBe('\nd29ybGQ=\n');
   expect(testcase['system-out'].length).toBe(1);
   expect(testcase['system-out'][0].trim()).toBe([
     `log here`


### PR DESCRIPTION
hi,

do you think this could be a solution for adding the path/extension to the report xml ? 
I actually dont know if this an problem from the server version of xray, but for me I actually get attachments without any extension/filetype. This actually results in Screenshots that cant be opened in the test execution in jira. 

this was an Solution by @mxschmitt that he actually added in a PR that was closed since pw team decided an extra reporter for xray would be better: https://github.com/microsoft/playwright/pull/22443/files 

I can try to add tests and additions if needed to help :-)