### PR TITLE
Add a file attribute to testsuite component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ class XrayJUnitReporter implements Reporter {
         skipped,
         time: duration / 1000,
         errors: 0,
+        file: suite.location?.file || '',
       },
       children
     };

--- a/tests/reporter-junit.spec.ts
+++ b/tests/reporter-junit.spec.ts
@@ -44,7 +44,9 @@ test('should render expected', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][0]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
+  expect(path.basename(xml['testsuites']['testsuite'][0]['$']['file'])).toBe('a.test.js');
   expect(xml['testsuites']['testsuite'][1]['$']['name']).toBe('b.test.js');
+  expect(path.basename(xml['testsuites']['testsuite'][1]['$']['file'])).toBe('b.test.js');
   expect(result.exitCode).toBe(0);
 });
 
@@ -243,6 +245,7 @@ test('should not render projects if they dont exist', async ({ runInlineTest }) 
   expect(xml['testsuites']['testsuite'][0]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
+  expect(path.basename(xml['testsuites']['testsuite'][0]['$']['file'])).toBe('a.test.js');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toBe('a.test.js');
   expect(result.exitCode).toBe(0);
@@ -270,6 +273,7 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][0]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][0]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][0]['$']['skipped']).toBe('0');
+  expect(path.basename(xml['testsuites']['testsuite'][0]['$']['file'])).toBe('a.test.js');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][0]['testcase'][0]['$']['classname']).toBe('a.test.js');
 
@@ -278,6 +282,7 @@ test('should render projects', async ({ runInlineTest }) => {
   expect(xml['testsuites']['testsuite'][1]['$']['tests']).toBe('1');
   expect(xml['testsuites']['testsuite'][1]['$']['failures']).toBe('0');
   expect(xml['testsuites']['testsuite'][1]['$']['skipped']).toBe('0');
+  expect(path.basename(xml['testsuites']['testsuite'][1]['$']['file'])).toBe('a.test.js');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['name']).toBe('one');
   expect(xml['testsuites']['testsuite'][1]['testcase'][0]['$']['classname']).toBe('a.test.js');
   expect(result.exitCode).toBe(0);


### PR DESCRIPTION
First of all, thank you for maintaining a great playwright report plugin!

We want to detect a file name of the test suite however it seems that this plugin doesn’t support it yet.

I understood `file` attribute isn't supported it by [Basic JUnit XML component](https://github.com/testmoapp/junitxml?tab=readme-ov-file#structure). But [Complete JUnit XML component](https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example) supports it.

So, I tried to add it. How about my change??