### PR TITLE
Fix for #13 JUnit XML empty while using with monocart network report

### DIFF
--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -13,7 +13,8 @@ class ContentTypeMapper{
       case 'application/zip':
         return '.zip';
       default:
-        throw new console.warn(`could not map filetype of: ${contentType} to a correct ending`);
+        console.warn(`could not map filetype of: ${contentType} to a correct ending`);
+        return '';
     }
   }
 }

--- a/src/contentType.mapper.ts
+++ b/src/contentType.mapper.ts
@@ -1,5 +1,4 @@
-export type FileExtension = 'image/png' | 'text/plain' | 'video/webm' | 'application/zip';
-
+export type FileExtension = 'image/png' | 'text/plain' | 'text/html' | 'video/webm' | 'application/zip';
 class ContentTypeMapper{
 
   getFileExtenion(contentType: FileExtension): string {
@@ -8,6 +7,8 @@ class ContentTypeMapper{
         return '.png';
       case 'text/plain':
         return '.txt';
+      case 'text/html':
+        return '.html';
       case 'video/webm':
         return '.webm';
       case 'application/zip':


### PR DESCRIPTION
Adding HTML content type and fixing the exception by returning an empty extension for unknown content types.

Relates to https://github.com/Xray-App/playwright-junit-reporter/issues/13