### PR TITLE
feat: add support for tags as properties (QLT-357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ const xrayOptions = {
   // These annotations are reported as <property name=''>value</property>.
   textContentAnnotations: ['test_description'],
 
+  // Whether to add <properties> with all tags; default is false
+  embedTagsAsProperties: true,
+
   // This will create a "testrun_evidence" property that contains all attachments. Each attachment is added as an inner <item> element.
   // Disables [[ATTACHMENT|path]] in the <system-out>.
   embedAttachmentsAsProperty: 'testrun_evidence',

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,14 +39,16 @@ class XrayJUnitReporter implements Reporter {
   private outputFile: string | undefined;
   private stripANSIControlSequences = false;
   private embedAnnotationsAsProperties = false;
+  private embedTagsAsProperties = false;
   private textContentAnnotations: string[] | undefined;
   private embedAttachmentsAsProperty: string | undefined;
 
 
-  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string } = {}) {
+  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, embedTagsAsProperties?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string } = {}) {
     this.outputFile = options.outputFile || reportOutputNameFromEnv();
     this.stripANSIControlSequences = options.stripANSIControlSequences || false;
     this.embedAnnotationsAsProperties = options.embedAnnotationsAsProperties || false;
+    this.embedTagsAsProperties = options.embedTagsAsProperties || false;
     this.textContentAnnotations = options.textContentAnnotations || [];
     this.embedAttachmentsAsProperty = options.embedAttachmentsAsProperty;
   }
@@ -181,6 +183,19 @@ class XrayJUnitReporter implements Reporter {
           };
           properties.children?.push(property);
         }
+      }
+    }
+
+    if (this.embedTagsAsProperties && test.tags) {
+      for (const tag of test.tags) {
+        const property: XMLEntry = {
+          name: 'property',
+          attributes: {
+            name: 'tag',
+            value: tag
+          }
+        };
+        properties.children?.push(property);
       }
     }
 


### PR DESCRIPTION
Just found your reporter today, love it and wanted to add the ability to include my test tags in my reports

Not sure if this is something you'd value this being added to your package as well, if not I'm happy to maintain a fork for our company to use