### PR TITLE
add option for removing testcases without the test_key property

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const xrayOptions = {
 
   // Whether to ignore tests that do not contain an annotation of type 'test_key'; default is false
   // This is useful, if you have tests without a test_key property in your testsuite, 
-  // but still want to import the report into xray cloud without those tests.
+  // but still want to import the report into Xray without those tests.
   ignoreTestCasesWithoutTestKey: false,
 
   // By default, annotation is reported as <property name='' value=''>.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ const xrayOptions = {
   // Whether to add <properties> with all annotations; default is false
   embedAnnotationsAsProperties: true,
 
+  // Whether to ignore tests that do not contain an annotation of type 'test_key'; default is false
+  // This is useful, if you have tests without a test_key property in your testsuite, 
+  // but still want to import the report into xray cloud without those tests.
+  ignoreTestCasesWithoutTestKey: false,
+
   // By default, annotation is reported as <property name='' value=''>.
   // These annotations are reported as <property name=''>value</property>.
   textContentAnnotations: ['test_description'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,14 @@ class XrayJUnitReporter implements Reporter {
   private embedAnnotationsAsProperties = false;
   private textContentAnnotations: string[] | undefined;
   private embedAttachmentsAsProperty: string | undefined;
-  private removeTestCasesWithoutTestKey: boolean = false;
+  private ignoreTestCasesWithoutTestKey: boolean = false;
 
 
-  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, removeTestCasesWithoutTestKey?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string } = {}) {
+  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, ignoreTestCasesWithoutTestKey?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string } = {}) {
     this.outputFile = options.outputFile || reportOutputNameFromEnv();
     this.stripANSIControlSequences = options.stripANSIControlSequences || false;
     this.embedAnnotationsAsProperties = options.embedAnnotationsAsProperties || false;
-    this.removeTestCasesWithoutTestKey = options.removeTestCasesWithoutTestKey || false;
+    this.ignoreTestCasesWithoutTestKey = options.ignoreTestCasesWithoutTestKey || false;
     this.textContentAnnotations = options.textContentAnnotations || [];
     this.embedAttachmentsAsProperty = options.embedAttachmentsAsProperty;
   }
@@ -108,7 +108,7 @@ class XrayJUnitReporter implements Reporter {
     const children: XMLEntry[] = [];
 
     suite.allTests().forEach(test => {
-      if (this.removeTestCasesWithoutTestKey && !hasAnnotationTestKey(test))
+      if (this.ignoreTestCasesWithoutTestKey && !hasAnnotationTestKey(test))
         return;
 
       ++tests;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,22 +42,15 @@ class XrayJUnitReporter implements Reporter {
   private textContentAnnotations: string[] | undefined;
   private embedAttachmentsAsProperty: string | undefined;
   private removeTestCasesWithoutTestKey: boolean = false;
-  private requiredTestKeyRegex: RegExp = RegExp('');
 
 
-  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, removeTestCasesWithoutTestKey?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string, requiredTestKeyRegex?: RegExp | string } = {}) {
+  constructor(options: { outputFile?: string, stripANSIControlSequences?: boolean, embedAnnotationsAsProperties?: boolean, removeTestCasesWithoutTestKey?: boolean, textContentAnnotations?: string[], embedAttachmentsAsProperty?: string } = {}) {
     this.outputFile = options.outputFile || reportOutputNameFromEnv();
     this.stripANSIControlSequences = options.stripANSIControlSequences || false;
     this.embedAnnotationsAsProperties = options.embedAnnotationsAsProperties || false;
     this.removeTestCasesWithoutTestKey = options.removeTestCasesWithoutTestKey || false;
     this.textContentAnnotations = options.textContentAnnotations || [];
     this.embedAttachmentsAsProperty = options.embedAttachmentsAsProperty;
-    if (!options.requiredTestKeyRegex)
-      this.requiredTestKeyRegex = RegExp('');
-    else if (typeof options.requiredTestKeyRegex === 'string')
-      this.requiredTestKeyRegex = RegExp(options.requiredTestKeyRegex);
-    else
-      this.requiredTestKeyRegex = options.requiredTestKeyRegex;
   }
 
   printsToStdio() {
@@ -129,7 +122,7 @@ class XrayJUnitReporter implements Reporter {
     this.totalFailures += failures;
 
     if (this.removeTestCasesWithoutTestKey)
-      children = removeTestCases(children, this.requiredTestKeyRegex);
+      children = removeTestCases(children);
 
     const entry: XMLEntry = {
       name: 'testsuite',
@@ -306,7 +299,7 @@ function serializeXML(entry: XMLEntry, tokens: string[], stripANSIControlSequenc
   tokens.push(`</${entry.name}>`);
 }
 
-function removeTestCases(entries: XMLEntry[], regexPattern: RegExp): XMLEntry[] {
+function removeTestCases(entries: XMLEntry[]): XMLEntry[] {
   let result: XMLEntry[] = [];
 
   result = entries.filter(entry => {
@@ -318,7 +311,7 @@ function removeTestCases(entries: XMLEntry[], regexPattern: RegExp): XMLEntry[] 
         if (child.children) {
           for (const property of child.children) {
             if (property.attributes) {
-              if (property.attributes?.name === 'test_key' && regexPattern.test(property.attributes?.value.toString()))
+              if (property.attributes?.name === 'test_key')
                 return true;
             }
           }

--- a/tests/reporter-junit.spec.ts
+++ b/tests/reporter-junit.spec.ts
@@ -540,6 +540,47 @@ test.describe('remove testcases without test_key property', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  test('missing option behaves like deactived', async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'playwright.config.ts': `
+        const xrayOptions = {
+        embedAnnotationsAsProperties: true
+      }
+      module.exports = {
+        reporter: [ ['${THIS_REPORTER}', xrayOptions] ],
+      };
+      `,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('one', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_key', description: 'CALC-1' });
+          expect(1).toBe(1);
+        });
+        test('two', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_id', description: '1234' });
+          expect(1).toBe(1);
+        });
+      `
+    }, { reporter: '' });
+    const xml = parseXML(result.output);
+    expect(xml['testsuites']['testsuite'][0]['testcase'].length).toBe(2);
+
+    const testcase_one = xml['testsuites']['testsuite'][0]['testcase'][0];
+    const testcase_two = xml['testsuites']['testsuite'][0]['testcase'][1];
+
+    expect(testcase_one['properties']).toBeTruthy();
+    expect(testcase_one['properties'][0]['property'].length).toBe(1);
+    expect(testcase_one['properties'][0]['property'][0]['$']['name']).toBe('test_key');
+    expect(testcase_one['properties'][0]['property'][0]['$']['value']).toBe('CALC-1');
+
+    expect(testcase_two['properties']).toBeTruthy();
+    expect(testcase_two['properties'][0]['property'].length).toBe(1);
+    expect(testcase_two['properties'][0]['property'][0]['$']['name']).toBe('test_id');
+    expect(testcase_two['properties'][0]['property'][0]['$']['value']).toBe('1234');
+
+    expect(result.exitCode).toBe(0);
+  });
+
   test('one test_key, activated option should remove testcase two', async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'playwright.config.ts': `

--- a/tests/reporter-junit.spec.ts
+++ b/tests/reporter-junit.spec.ts
@@ -496,3 +496,114 @@ test.describe('report location', () => {
     expect(fs.existsSync(testInfo.outputPath('foo', 'bar', 'baz', 'my-report.xml'))).toBe(true);
   });
 });
+
+test.describe('remove testcases without test_key property', () => {
+  test('deactivated option should contain all tests', async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'playwright.config.ts': `
+        const xrayOptions = {
+        embedAnnotationsAsProperties: true,
+        ignoreTestCasesWithoutTestKey: false  // this is default
+      }
+      module.exports = {
+        reporter: [ ['${THIS_REPORTER}', xrayOptions] ],
+      };
+      `,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('one', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_key', description: 'CALC-1' });
+          expect(1).toBe(1);
+        });
+        test('two', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_id', description: '1234' });
+          expect(1).toBe(1);
+        });
+      `
+    }, { reporter: '' });
+    const xml = parseXML(result.output);
+    expect(xml['testsuites']['testsuite'][0]['testcase'].length).toBe(2);
+
+    const testcase_one = xml['testsuites']['testsuite'][0]['testcase'][0];
+    const testcase_two = xml['testsuites']['testsuite'][0]['testcase'][1];
+
+    expect(testcase_one['properties']).toBeTruthy();
+    expect(testcase_one['properties'][0]['property'].length).toBe(1);
+    expect(testcase_one['properties'][0]['property'][0]['$']['name']).toBe('test_key');
+    expect(testcase_one['properties'][0]['property'][0]['$']['value']).toBe('CALC-1');
+
+    expect(testcase_two['properties']).toBeTruthy();
+    expect(testcase_two['properties'][0]['property'].length).toBe(1);
+    expect(testcase_two['properties'][0]['property'][0]['$']['name']).toBe('test_id');
+    expect(testcase_two['properties'][0]['property'][0]['$']['value']).toBe('1234');
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('one test_key, activated option should remove testcase two', async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'playwright.config.ts': `
+        const xrayOptions = {
+        embedAnnotationsAsProperties: true,
+        ignoreTestCasesWithoutTestKey: true
+      }
+      module.exports = {
+        reporter: [ ['${THIS_REPORTER}', xrayOptions] ],
+      };
+      `,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('one', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_key', description: 'CALC-1' });
+          expect(1).toBe(1);
+        });
+        test('two', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_id', description: '1234' });
+          expect(1).toBe(1);
+        });
+      `
+    }, { reporter: '' });
+    const xml = parseXML(result.output);
+    expect(xml['testsuites']['testsuite'][0]['testcase'].length).toBe(1);
+
+    const testcase_one = xml['testsuites']['testsuite'][0]['testcase'][0];
+    const testcase_two = xml['testsuites']['testsuite'][0]['testcase'][1];
+
+    expect(testcase_one['properties']).toBeTruthy();
+    expect(testcase_one['properties'][0]['property'].length).toBe(1);
+    expect(testcase_one['properties'][0]['property'][0]['$']['name']).toBe('test_key');
+    expect(testcase_one['properties'][0]['property'][0]['$']['value']).toBe('CALC-1');
+
+    expect(testcase_two).toBeFalsy();
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('no test_keys, remove all testcases', async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'playwright.config.ts': `
+        const xrayOptions = {
+        embedAnnotationsAsProperties: true,
+        ignoreTestCasesWithoutTestKey: true
+      }
+      module.exports = {
+        reporter: [ ['${THIS_REPORTER}', xrayOptions] ],
+      };
+      `,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('one', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_id', description: '1235' });
+          expect(1).toBe(1);
+        });
+        test('two', async ({}, testInfo) => {
+          testInfo.annotations.push({ type: 'test_id', description: '1234' });
+          expect(1).toBe(1);
+        });
+      `
+    }, { reporter: '' });
+    const xml = parseXML(result.output);
+    expect(xml['testsuites']['testsuite'][0]).toBeTruthy();
+    expect(xml['testsuites']['testsuite'][0]['testcase']).toBeFalsy();
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
This commit removes all testcases from the report, that do not contain the "test_key" property - if the option in playwright is set.

when running my testsuite of 100+ tests, I mark most of the tests with a test_key property. However, if a test does not contain that property, the import to xray-cloud fails. Since I don't want to go through the xml report myself to remove all the tests without a test_key (and I will always have some tests without a test_key like global-setup tests), I want to throw out all testcases I dont need - thus this PR. 
I also added an optional Regex, that the test_key property needs to match, and filters out all testcases that do not match aswell.

example 

```typescript
const xrayOptions = {
    embedAnnotationsAsProperties: true,
    textContentAnnotations: ["test_description"],
    outputFile: "./report-export/xray-report.xml",

    removeTestCasesWithoutTestKey: true,  // default is false
    requiredTestKeyRegex: /^ABC-\d+$/,  // "ABC-" as a string also works. has no effect if previous option is set to false
};

export default defineConfig({
    reporter: [
        ["@xray-app/playwright-junit-reporter", xrayOptions],
    ],
}
```

I really do need this feature and I planned on using my own fork, but maybe you are also interested in it and I dont need to maintain my own fork.

Please bear with me, this is the first Pull Request I am doing to a public repostory, feedback is welcome <3