### PR TITLE
Bump support for Playwright 1.62.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'     
+          node-version: '20'     
       - name: Install dependencies and build
         run: npm ci
       - name: Run ESLint

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@xray-app/playwright-junit-reporter",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -43,10 +43,10 @@
         "source-map-support": "^0.5.21",
         "typescript": "^5.3.2",
         "ws": "^8.17.1",
-        "xml2js": "^0.5.0"
+        "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5834,10 +5834,11 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xray-app/playwright-junit-reporter",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xray-app/playwright-junit-reporter",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xray-app/playwright-junit-reporter",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@playwright/test": "^1.61.0",
+        "@playwright/test": "1.62.1",
         "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "^18.7.23",
         "@types/sinonjs__fake-timers": "^8.1.2",
@@ -35,7 +35,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "mock-fs": "^5.1.4",
         "nyc": "^15.1.0",
-        "playwright": "^1.61.0",
+        "playwright": "1.62.1",
         "playwright-test-coverage": "^1.2.0",
         "prettier": "^2.7.1",
         "rimraf": "^5.0.0",
@@ -653,19 +653,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4440,35 +4440,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright-test-coverage": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "/dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "clean": "rimraf dist test-results .nyc_output",
@@ -65,7 +65,7 @@
     "source-map-support": "^0.5.21",
     "typescript": "^5.3.2",
     "ws": "^8.17.1",
-    "xml2js": "^0.5.0"
+    "xml2js": "^0.6.2"
   },
   "dependencies": {
     "@babel/code-frame": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xray-app/playwright-junit-reporter",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "generate an enhanced JUnit XML report suitable for Xray with the playwright test results",
   "main": "./dist/index.js",
   "types": "./dist/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xray-app/playwright-junit-reporter",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "generate an enhanced JUnit XML report suitable for Xray with the playwright test results",
   "main": "./dist/index.js",
   "types": "./dist/types.d.ts",
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/Xray-App/playwright-junit-reporter",
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "1.62.1",
     "@sinonjs/fake-timers": "^9.1.2",
     "@types/node": "^18.7.23",
     "@types/sinonjs__fake-timers": "^8.1.2",
@@ -57,7 +57,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "mock-fs": "^5.1.4",
     "nyc": "^15.1.0",
-    "playwright": "^1.61.0",
+    "playwright": "1.62.1",
     "playwright-test-coverage": "^1.2.0",
     "prettier": "^2.7.1",
     "rimraf": "^5.0.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -16,8 +16,8 @@
 
 import { colors, ms as milliseconds, monotonicTime } from 'playwright-core/lib/utilsBundle';
 // @ts-ignore
-import { iso } from 'playwright-core/lib/coreBundle';
-const { parseStackFrame } = iso;
+import { utils } from 'playwright-core/lib/coreBundle';
+const { parseStackFrame } = utils;
 
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- Bump `playwright` / `@playwright/test` to 1.62.1
- `playwright-core/lib/coreBundle` renamed the `iso` export to `utils`; `parseStackFrame` now comes from `utils`
- Bump package version to 0.14.1

Closes #51

## Test plan
- [x] `npm test` — 25/25 passing

## Request
Could a maintainer publish `0.14.1` to npm once this merges? Package currently only supports up to Playwright 1.61 on the registry.