### PR TITLE
Update Node.js version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'     
+          node-version: '20'   
       - name: Install dependencies and build
         run: npm ci
       - name: Run ESLint


### PR DESCRIPTION
## Summary
- Bump node-version in publish workflow.

Closes #52
